### PR TITLE
refactor: remove dto from services

### DIFF
--- a/src/main/java/com/novelbot/api/controller/ChatController.java
+++ b/src/main/java/com/novelbot/api/controller/ChatController.java
@@ -36,7 +36,7 @@ public class ChatController {
     public ResponseEntity<Void> createChatroom(@RequestBody ChatroomCreateRequest request,
             @RequestHeader("Authorization") String authorizationHeader) {
         String token = extractTokenFromHeader(authorizationHeader);
-        chatroomService.createChatroom(request, token);
+        chatroomService.createChatroom(request.getNovelId(), request.getChatTitle(), token);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/novelbot/api/controller/QueryController.java
+++ b/src/main/java/com/novelbot/api/controller/QueryController.java
@@ -26,8 +26,7 @@ public class QueryController {
     @Operation(summary = "질문 생성", description = "새로운 질문을 생성하는 API")
     @PostMapping("/queries")
     public ResponseEntity<Void> createQuery(@PathVariable Integer chatId, @RequestBody QueryCreateRequest request) {
-        request.setChatId(chatId);
-        queryService.createQuery(request);
+        queryService.createQuery(chatId, request.getQueryContent(), request.getPageNumber());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/novelbot/api/service/chat/ChatroomService.java
+++ b/src/main/java/com/novelbot/api/service/chat/ChatroomService.java
@@ -3,7 +3,6 @@ package com.novelbot.api.service.chat;
 import com.novelbot.api.domain.Chatroom;
 import com.novelbot.api.domain.Novel;
 import com.novelbot.api.domain.User;
-import com.novelbot.api.dto.chat.ChatroomCreateRequest;
 import com.novelbot.api.dto.chat.ChatroomDto;
 import com.novelbot.api.mapper.chat.ChatroomDtoMapper;
 import com.novelbot.api.config.JwtTokenValidator;
@@ -39,13 +38,12 @@ public class ChatroomService {
     }
 
     // 채팅방 생성
-    public void createChatroom(ChatroomCreateRequest chatroomCreateRequest, String token) {
-        if (chatroomCreateRequest == null || chatroomCreateRequest.getNovelId() == null
-                || chatroomCreateRequest.getNovelId() <= 0) {
+    public void createChatroom(Integer novelId, String chatTitle, String token) {
+        if (novelId == null || novelId <= 0) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "novelId가 올바르지 않은 형식입니다.");
         }
-        if (chatroomCreateRequest.getChatTitle() == null || chatroomCreateRequest.getChatTitle().isEmpty()) {
+        if (chatTitle == null || chatTitle.isEmpty()) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST, "채팅방 제목이 비어 있습니다.");
         }
@@ -59,12 +57,11 @@ public class ChatroomService {
         User user = userRepository.findByUserName(username).orElseThrow(
                 () -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."));
-        Novel novel = novelRepository.findById(chatroomCreateRequest.getNovelId()).orElseThrow(
+        Novel novel = novelRepository.findById(novelId).orElseThrow(
                 () -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND, "소설을 찾을 수 없습니다."));
 
-        Chatroom chatroom = new Chatroom(
-                chatroomCreateRequest.getChatTitle(), user, novel);
+        Chatroom chatroom = new Chatroom(chatTitle, user, novel);
 
         try {
             chatRepository.save(chatroom);

--- a/src/main/java/com/novelbot/api/service/chat/QueryService.java
+++ b/src/main/java/com/novelbot/api/service/chat/QueryService.java
@@ -2,7 +2,6 @@ package com.novelbot.api.service.chat;
 
 import com.novelbot.api.domain.Chatroom;
 import com.novelbot.api.domain.Queries;
-import com.novelbot.api.dto.chat.QueryCreateRequest;
 import com.novelbot.api.dto.chat.QueryDto;
 import com.novelbot.api.mapper.chat.QueryDtoMapper;
 import com.novelbot.api.repository.ChatRepository;
@@ -33,16 +32,15 @@ public class QueryService {
      * 새로운 질문 생성
      */
     @Transactional
-    public void createQuery(QueryCreateRequest request) {
-        if (request == null || request.getChatId() == null || request.getQueryContent() == null
-                || request.getQueryContent().isEmpty()) {
+    public void createQuery(Integer chatId, String queryContent, Integer pageNumber) {
+        if (chatId == null || queryContent == null || queryContent.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
         }
 
-        Chatroom chatroom = chatRepository.findById(request.getChatId())
+        Chatroom chatroom = chatRepository.findById(chatId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."));
 
-        Queries query = new Queries(request.getQueryContent(), request.getPageNumber(), chatroom);
+        Queries query = new Queries(queryContent, pageNumber, chatroom);
         queryRepository.save(query);
     }
 


### PR DESCRIPTION
## Summary
- drop DTO usage in ChatroomService and pass primitive parameters
- simplify QueryService create logic to avoid dependency on QueryCreateRequest

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_689069da931c8320bc4a1798a4542056